### PR TITLE
use destroy instead of clear

### DIFF
--- a/source/thrift/async/libevent.d
+++ b/source/thrift/async/libevent.d
@@ -392,7 +392,7 @@ private:
       TAsyncEventReason.NORMAL;
     (*(cast(TSocketEventListener*)arg))(reason);
     GC.removeRange(arg);
-    clear(arg);
+    destroy(arg);
     free(arg);
   }
 
@@ -402,7 +402,7 @@ private:
     assert(flags & EV_TIMEOUT);
     (*(cast(void delegate()*)arg))();
     GC.removeRange(arg);
-    clear(arg);
+    destroy(arg);
     free(arg);
   }
 

--- a/source/thrift/internal/ssl.d
+++ b/source/thrift/internal/ssl.d
@@ -179,7 +179,7 @@ Exception getSSLException(string location = null, string clientFile = __FILE__,
   Exception exception;
 
   void initMessage() {
-    message.clear();
+    message.destroy();
     hadMessage = false;
     if (!location.empty) {
       message ~= location;

--- a/source/thrift/transport/ssl.d
+++ b/source/thrift/transport/ssl.d
@@ -518,7 +518,7 @@ private:
       const(char)* file, int line)
     {
       GC.removeRange(l);
-      clear(cast(Mutex)l);
+      destroy(cast(Mutex)l);
       free(l);
     }
 


### PR DESCRIPTION
`clear` is an alias of `destroy` in old version,
but with dmd2.068 or later, `clear` is redefined for dict,
hence codes are not compiled.

Change-Id: Iff993625b38de4bbf5e7f37e08e0a481761f2336
